### PR TITLE
Extract and add dd.* attributes from log record to log entry dict

### DIFF
--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -66,6 +66,10 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
             "syslog.severity": record.levelname,
         }
 
+        # Add special `dd.` log record attributes added by `ddtrace` library
+        # For example: dd.trace_id, dd.span_id, dd.service, dd.env, dd.version, etc
+        log_entry_dict.update(self.get_datadog_attributes(record))
+
         celery_request = self.get_celery_request(record)
         if celery_request is not None:
             log_entry_dict["celery.request_id"] = celery_request.id
@@ -152,6 +156,10 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
         if record.name == "celery.worker.strategy" and record.args and isinstance(record.args[0], Request):
             return record.args[0]
         return django_datadog_logger.celery.get_celery_request()
+
+    def get_datadog_attributes(self, record):
+        """Helper to extract dd.* attributes from the log record."""
+        return {attr_name: record.__dict__[attr_name] for attr_name in record.__dict__ if attr_name.startswith("dd.")}
 
     def get_wsgi_request(self):
         return django_datadog_logger.wsgi.get_wsgi_request()


### PR DESCRIPTION
The [ddtrace](https://pypi.org/project/ddtrace/) library has an option to inject tracing context data into log records: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#logs-injection.

This change adds a helper to look for those attributes and add them automatically to the log entry created by this library.


```python
# log.py

# Patch logging library to inject dd.* attributes on log records
import ddtrace
ddtrace.patch(logging=True)

# Configure logger with DataDogJSONFormatter
import logging
from django_datadog_logger.formatters.datadog import DataDogJSONFormatter

logger = logging.root

handler = logging.StreamHandler()
handler.formatter = DataDogJSONFormatter()
logger.addHandler(handler)
logger.setLevel(logging.INFO)


# Log a test message
logger.info("test")
```


```
$ DD_SERVICE=django DD_ENV=test DD_VERSION=1234 python log.py
{"message": "test", "logger.name": "root", "logger.thread_name": "MainThread", "logger.method_name": "<module>", "syslog.timestamp": "2021-08-23T18:26:10.391099+00:00", "syslog.severity": "INFO", "dd.version": "1234", "dd.env": "test", "dd.service": "django", "dd.trace_id": "0", "dd.span_id": "0"}
```


If you remove the call to `datadog.patch(logging=True)` you end up with:

```
$ python test.py
{"message": "test", "logger.name": "root", "logger.thread_name": "MainThread", "logger.method_name": "<module>", "syslog.timestamp": "2021-08-23T18:27:47.951461+00:00", "syslog.severity": "INFO"}
```