### PR TITLE
Prevent the logger from throwing a DisallowedHost error

### DIFF
--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -6,6 +6,7 @@ import pytz
 import json_log_formatter
 from celery.worker.request import Request
 from django.conf import settings
+from django.core.exceptions import DisallowedHost
 from django.http.request import split_domain_port
 from rest_framework.compat import unicode_http_header
 from rest_framework.utils.mediatypes import _MediaType
@@ -80,7 +81,10 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
         if wsgi_request is not None:
             log_entry_dict["network.client.ip"] = get_client_ip(wsgi_request)
 
-            domain, port = split_domain_port(wsgi_request.get_host())
+            try:
+                domain, port = split_domain_port(wsgi_request.get_host())
+            except DisallowedHost:
+                domain, port = None, None
 
             log_entry_dict["http.url"] = wsgi_request.get_full_path()
             log_entry_dict["http.url_details.host"] = domain


### PR DESCRIPTION
This PR includes 2 changes, one in each commit:

1. Switch from `syslog.severity` to `level` so that DD automatically pics up the log level
2. I found that my app was trying to log a `DisallowedHost` error when the logger would raise another one. This change prevents the logger from throwing a `DisallowedHost` error.