### PR TITLE
Handle `exc_info=True` used outside of exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ ENV/
 
 # IDE settings
 .vscode/
+.idea/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,8 +79,8 @@ Ready to contribute? Here's how to set up `django-datadog-logger` for local deve
 5. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-    $ flake8 django-datadog-logger tests
-    $ python setup.py test or pytest
+    $ flake8 django_datadog_logger tests
+    $ make test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -105,14 +105,6 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should work for Python 3.6, 3.7 and 3.8, and for PyPy. Check
    https://travis-ci.com/namespace-ee/django-datadog-logger/pull_requests
    and make sure that the tests pass for all supported Python versions.
-
-Tips
-----
-
-To run a subset of tests::
-
-
-    $ python -m unittest tests.test_django_datadog_logger
 
 Deploying
 ---------

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,13 @@ lint: ## check style with flake8
 	flake8 django_datadog_logger tests
 
 test: ## run tests quickly with the default Python
-	python setup.py test
+	DJANGO_SETTINGS_MODULE=tests.settings python setup.py test
 
 test-all: ## run tests on every Python version with tox
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	coverage run --source django_datadog_logger setup.py test
+	DJANGO_SETTINGS_MODULE=tests.settings coverage run --source django_datadog_logger setup.py test
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html

--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -144,7 +144,7 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
             if hasattr(record, "status_code"):
                 log_entry_dict["error.kind"] = record.status_code
                 log_entry_dict["error.message"] = record.msg
-            else:
+            elif record.exc_info[0] is not None:
                 log_entry_dict["error.kind"] = record.exc_info[0].__name__
                 for msg in traceback.format_exception_only(record.exc_info[0], record.exc_info[1]):
                     log_entry_dict["error.message"] = msg.strip()

--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -9,7 +9,6 @@ from django.core.exceptions import DisallowedHost
 from django.http.request import split_domain_port
 from django.urls import resolve, NoReverseMatch, Resolver404
 from rest_framework.compat import unicode_http_header
-from rest_framework.exceptions import AuthenticationFailed
 
 from django_datadog_logger.encoders import SafeJsonEncoder
 from django_datadog_logger.celery import get_task_name, get_celery_request

--- a/django_datadog_logger/middleware/request_id.py
+++ b/django_datadog_logger/middleware/request_id.py
@@ -12,7 +12,7 @@ def generate_request_id():
 
 def get_or_create_request_id(request):
     request_id = request.META.get("HTTP_X_REQUEST_ID")
-    if request_id and re.match("^[a-zA-Z0-9+/=\-]{20,200}$", request_id):
+    if request_id and re.match("^[a-zA-Z0-9+/=-]{20,200}$", request_id):
         return request_id
     else:
         return generate_request_id()

--- a/django_datadog_logger/middleware/request_log.py
+++ b/django_datadog_logger/middleware/request_log.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-from django.conf import settings
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 logger = logging.getLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,5 +16,6 @@ universal = 1
 
 [flake8]
 exclude = docs
+max-line-length = 120
 
 [aliases]

--- a/tests/test_django_datadog_logger.py
+++ b/tests/test_django_datadog_logger.py
@@ -1,21 +1,33 @@
-#!/usr/bin/env python
-
 """Tests for `django_datadog_logger` package."""
-
-
+import logging
 import unittest
 
-from django_datadog_logger import *
+from django.conf import settings
+
+from django_datadog_logger.formatters.datadog import DataDogJSONFormatter
 
 
-class TestDjango_datadog_logger(unittest.TestCase):
-    """Tests for `django_datadog_logger` package."""
+class DjangoDatadogLoggerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not settings.configured:
+            settings.configure()
 
-    def setUp(self):
-        """Set up test fixtures, if any."""
+    def test_format_json_accepts_a_tuple_of_nones_as_exc_info(self):
+        """
+        When logger is called with exc_info=True, then the exc_info
+        attribute of the LogRecord is a tuple of (None, None, None).
+        """
+        record = logging.LogRecord(
+            'foo',
+            logging.ERROR,
+            'foo.py',
+            42,
+            'This is an error',
+            None,
+            (None, None, None)
+        )
+        formatter = DataDogJSONFormatter()
+        json_record = formatter.json_record('Foo', {}, record)
 
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-
-    def test_000_something(self):
-        """Test something."""
+        self.assertEqual(json_record.get('error.kind'), None)

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ commands = flake8 django_datadog_logger tests
 setenv =
     PYTHONPATH = {toxinidir}
 
-commands = python setup.py test
+commands = DJANGO_SETTINGS_MODULE=tests.settings python setup.py test


### PR DESCRIPTION
Fixes: https://github.com/namespace-ee/django-datadog-logger/issues/18

I added a test settings file to make tests start. I couldn't find a better way to setup Django settings. I amended the setup by prefixing test commands with `DJANGO_SETTINGS_MODULE=tests.settings`. Now `make test`, `make coverage` and `tox` all work.

To make `tox` work I had to:
1. set max line length to 120 characters (to match pyproject.toml)
2. remove an incorrectly escaped hyphen from the request ID matcher

I'm sorry for putting it all in a single PR. I did that because I wasn't able to run all the required commands mentioned from CONTRIBUTING.rst. I may extract the actual fix into a separate one if you prefer. The changes are cleanly split between commits so it would be an easy job.