### PR TITLE
Skip internal Django exception for 4XX responses in ErrorLoggingMiddleware

### DIFF
--- a/django_datadog_logger/middleware/error_log.py
+++ b/django_datadog_logger/middleware/error_log.py
@@ -1,5 +1,8 @@
 import logging
 
+from django.core.exceptions import PermissionDenied, BadRequest, SuspiciousOperation
+from django.http import Http404
+from django.http.multipartparser import MultiPartParserError
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +15,11 @@ class ErrorLoggingMiddleware:
         return self.get_response(request)
 
     def process_exception(self, request, exception):
+        if isinstance(
+            exception,
+            (PermissionDenied, Http404, MultiPartParserError, BadRequest, SuspiciousOperation),
+        ):
+            return
         logger.exception(exception)
 
     def process_response(self, request, response):


### PR DESCRIPTION
As discussed in the linked issue, these exceptions should be treated differently, because they are used internally by Django to stop processing the request, and return specific 4XX error back to the user.

Fix #17