### PR TITLE
Optimise status code conditions

### DIFF
--- a/django_datadog_logger/middleware/request_log.py
+++ b/django_datadog_logger/middleware/request_log.py
@@ -26,7 +26,7 @@ class RequestLoggingMiddleware:
             duration_seconds = time.time() - request.request_start_time
             log_entry_dict["duration"] = duration_seconds * 1000000000.0
 
-        if response.status_code in range(400, 500):
+        if 400 <= response.status_code < 500:
             log_entry_dict["error.kind"] = response.status_code
             log_entry_dict["error.message"] = response.reason_phrase
             if hasattr(response, "data") and isinstance(response.data, (list, dict, ReturnDict)):
@@ -35,7 +35,7 @@ class RequestLoggingMiddleware:
                 f"HTTP {response.status_code} {response.reason_phrase}",
                 extra=log_entry_dict,
             )
-        elif response.status_code in range(500, 600):
+        elif 500 <= response.status_code < 600:
             log_entry_dict["error.kind"] = response.status_code
             log_entry_dict["error.message"] = response.reason_phrase
             logger.error(


### PR DESCRIPTION
The current conditions to match which level of log to use are more expensive that they should be. Instead of building a range object and do a lookup in it, which -in the worst case- can go through 100 of elements, it's 2x faster to compare with the 2 integers of the bound:

```
>>> import timeit
>>> timeit.timeit("x in range(400, 500)", setup="from random import randint;x = randint(100, 1000)")
0.08440266699471977
>>> timeit.timeit("400 <= x < 500", setup="from random import randint;x = randint(100, 1000)")
0.0354189580102684
```

As this middleware runs on every request, and info logs go through the if + elif condition, I think this small optimisation, while not life changing, is nice to have.