### PR TITLE
Replace pytz by zoneinfo from the stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint: ## check style with flake8
 	flake8 django_datadog_logger tests
 
 test: ## run tests quickly with the default Python
-	DJANGO_SETTINGS_MODULE=tests.settings python setup.py test
+	DJANGO_SETTINGS_MODULE=tests.settings python -m unittest discover
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -4,8 +4,12 @@ import traceback
 import typing
 from logging import LogRecord
 
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
 import json_log_formatter
-import pytz
 from django.conf import settings
 from django.core.exceptions import DisallowedHost
 from django.http.request import split_domain_port, HttpRequest
@@ -77,7 +81,9 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
             "logger.name": record.name,
             "logger.thread_name": record.threadName,
             "logger.method_name": record.funcName,
-            "date": pytz.utc.localize(datetime.datetime.utcfromtimestamp(record.created)).isoformat(),
+            "date": (
+                datetime.datetime.utcfromtimestamp(record.created).replace(tzinfo=zoneinfo.ZoneInfo("UTC")).isoformat()
+            ),
             "status": record.levelname,
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 JSON-log-formatter
 Django
 djangorestframework
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 JSON-log-formatter
 Django
 djangorestframework
-pytz
+backports.zoneinfo;python_version<"3.9"

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ with open("requirements.txt") as requirements_file:
 
 setup_requirements = []
 
-test_requirements = []
-
-
 setup(
     author="Lenno Nagel",
     author_email="lenno@namespace.ee",
@@ -50,8 +47,6 @@ setup(
     name="django-datadog-logger",
     packages=find_packages(include=["django_datadog_logger", "django_datadog_logger.*"]),
     setup_requires=setup_requirements,
-    test_suite="tests",
-    tests_require=test_requirements,
     url="https://github.com/namespace-ee/django-datadog-logger",
     version="0.7.1",
     zip_safe=False,


### PR DESCRIPTION
The Python community is moving away from pytz now that the standard library provides a module `zoneinfo` to work with timezones. Installing [the backport](https://pypi.org/project/backports.zoneinfo/) on older Python versions.

Builds on top of: https://github.com/namespace-ee/django-datadog-logger/pull/36

Refs #35