### PR TITLE
Running 'python setup.py test' is no longer supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint: ## check style with flake8
 	flake8 django_datadog_logger tests
 
 test: ## run tests quickly with the default Python
-	DJANGO_SETTINGS_MODULE=tests.settings python setup.py test
+	DJANGO_SETTINGS_MODULE=tests.settings python -m unittest discover
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ with open("requirements.txt") as requirements_file:
 
 setup_requirements = []
 
-test_requirements = []
-
-
 setup(
     author="Lenno Nagel",
     author_email="lenno@namespace.ee",
@@ -50,8 +47,6 @@ setup(
     name="django-datadog-logger",
     packages=find_packages(include=["django_datadog_logger", "django_datadog_logger.*"]),
     setup_requires=setup_requirements,
-    test_suite="tests",
-    tests_require=test_requirements,
     url="https://github.com/namespace-ee/django-datadog-logger",
     version="0.7.1",
     zip_safe=False,


### PR DESCRIPTION
Has been deprecated since 2019: https://github.com/pypa/setuptools/pull/1878