### PR TITLE
FEATURE: add support for Python 3.12 in setup, fix deprecation warning

### DIFF
--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -4,6 +4,11 @@ import traceback
 import typing
 from logging import LogRecord
 
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
 import json_log_formatter
 from django.conf import settings
 from django.core.exceptions import DisallowedHost
@@ -77,7 +82,7 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
             "logger.thread_name": record.threadName,
             "logger.method_name": record.funcName,
             "date": (
-                datetime.datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat()
+                datetime.datetime.fromtimestamp(record.created, tz=zoneinfo.ZoneInfo("UTC")).isoformat()
             ),
             "status": record.levelname,
         }

--- a/django_datadog_logger/formatters/datadog.py
+++ b/django_datadog_logger/formatters/datadog.py
@@ -4,11 +4,6 @@ import traceback
 import typing
 from logging import LogRecord
 
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo
-
 import json_log_formatter
 from django.conf import settings
 from django.core.exceptions import DisallowedHost
@@ -82,7 +77,7 @@ class DataDogJSONFormatter(json_log_formatter.JSONFormatter):
             "logger.thread_name": record.threadName,
             "logger.method_name": record.funcName,
             "date": (
-                datetime.datetime.utcfromtimestamp(record.created).replace(tzinfo=zoneinfo.ZoneInfo("UTC")).isoformat()
+                datetime.datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat()
             ),
             "status": record.levelname,
         }

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     description="Django DataDog Logger integration package.",
     install_requires=requirements,


### PR DESCRIPTION
This PR adds support for Python 3.12 and fixes the deprecation warning with support being dropped for `datetime.utcfromtimestamp()` in the future