### PR TITLE
Make RequestLoggingMiddleware async capable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 JSON-log-formatter
 Django
+asgiref
 djangorestframework
 backports.zoneinfo;python_version<"3.9"


### PR DESCRIPTION
Took some inspiration from [`django-cors-headers`](https://github.com/adamchainz/django-cors-headers/blob/main/src/corsheaders/middleware.py) and Django's `MiddlewareMixin`.

More details on why this is important: https://jonathanadly.com/is-async-django-ready-for-prime-time#heading-async-middleware