### PR TITLE
Fix false-positive in not_recursive and drop per-call inspect.stack()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,17 @@
 # History
 
+## Unreleased
+
+-   Fixed: `not_recursive` raised a false `RecursionDetected` when an
+    unrelated function sharing the guarded function's name appeared on the
+    call stack -- it matched on frame *name* rather than actual re-entrancy.
+    Re-entrancy is now tracked with a per-function thread-local flag.
+-   Performance: `not_recursive` no longer calls `inspect.stack()` on every
+    call (which resolved the source file of every frame on the stack),
+    removing a per-call cost from the hot logging path -- the decorator wraps
+    the per-log-record `get_wsgi_request_user` / `get_wsgi_request_auth`
+    helpers.
+
 ## 0.6.2 (2023-04-27)
 
 -   Fixed case where accessing request.auth may raise errors

--- a/django_datadog_logger/recursion.py
+++ b/django_datadog_logger/recursion.py
@@ -1,4 +1,4 @@
-import inspect
+import threading
 from functools import wraps
 
 
@@ -7,16 +7,32 @@ class RecursionDetected(RuntimeError):
 
 
 def not_recursive(f):
+    """Raise :class:`RecursionDetected` if ``f`` is re-entered (directly or
+    indirectly) while a call is already in progress on the same thread.
+
+    Re-entrancy is tracked with a per-function thread-local flag. This is O(1)
+    and, unlike the previous implementation, does not call ``inspect.stack()``
+    on every call -- that walked the whole stack and resolved the source file
+    of every frame, a measurable per-call cost on hot paths such as the
+    per-log-record request introspection this decorator guards.
+
+    The flag is bound to this specific function (the closure), so the guard
+    triggers on actual re-entrancy only: an unrelated function that merely
+    shares ``f``'s name no longer causes a false ``RecursionDetected``, and two
+    distinct guarded functions with the same name no longer block each other.
+    The thread-local scope keeps concurrent calls on different threads
+    independent.
     """
-    raise an exception if recursive
-    """
+    state = threading.local()
 
     @wraps(f)
     def wrapper(*args, **kwargs):
-        for frame in inspect.stack():
-            if f.__name__ == frame.function:
-                raise RecursionDetected(f"function '{f.__name__}' is recursive")
-
-        return f(*args, **kwargs)
+        if getattr(state, "in_flight", False):
+            raise RecursionDetected(f"function '{f.__name__}' is recursive")
+        state.in_flight = True
+        try:
+            return f(*args, **kwargs)
+        finally:
+            state.in_flight = False
 
     return wrapper

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,119 @@
+"""Tests for the ``not_recursive`` re-entrancy guard."""
+
+import inspect
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from django_datadog_logger.recursion import RecursionDetected, not_recursive
+
+
+class TestNotRecursive:
+    def test_blocks_direct_recursion(self):
+        """A guarded function that calls itself raises RecursionDetected
+        instead of recursing — the contract the formatter relies on."""
+        calls = []
+
+        @not_recursive
+        def recursive():
+            calls.append(1)
+            recursive()
+
+        with pytest.raises(RecursionDetected):
+            recursive()
+        assert calls == [1]
+
+    def test_blocks_indirect_recursion(self):
+        """Re-entry through an intermediate call is also blocked — the real
+        formatter scenario (helper -> logging -> formatter -> helper)."""
+
+        @not_recursive
+        def outer():
+            def intermediate():
+                outer()
+
+            intermediate()
+
+        with pytest.raises(RecursionDetected):
+            outer()
+
+    def test_allows_sequential_calls_including_after_an_error(self):
+        """The in-flight flag is always cleared, so independent sequential
+        calls keep working even after one raised."""
+
+        @not_recursive
+        def flaky(should_raise):
+            if should_raise:
+                raise ValueError("boom")
+            return "ok"
+
+        assert flaky(False) == "ok"
+        with pytest.raises(ValueError):
+            flaky(True)
+        assert flaky(False) == "ok"
+
+    def test_does_not_false_positive_on_unrelated_same_named_frame(self):
+        """A non-recursive call must not be blocked just because an unrelated
+        function sharing the guarded function's name is on the call stack.
+
+        Two independently decorated functions both named ``helper`` — ``root``
+        calls ``leaf`` exactly once. That is not recursion, but a guard that
+        matches on frame *name* rather than actual re-entrancy raises
+        RecursionDetected because ``root``'s frame (also named ``helper``) is
+        still on the stack when ``leaf`` runs.
+        """
+
+        def make_guarded(body):
+            @not_recursive
+            def helper():
+                return body()
+
+            return helper
+
+        leaf = make_guarded(lambda: "leaf-value")
+        root = make_guarded(leaf)
+
+        assert leaf.__name__ == root.__name__ == "helper"
+        assert root() == "leaf-value"
+
+    def test_does_not_walk_the_stack(self):
+        """The guard must not call ``inspect.stack()`` — that resolved the
+        source file of every frame on the stack, on every call, which is a
+        per-call cost on the hot per-log-record logging path."""
+
+        @not_recursive
+        def guarded():
+            return "ok"
+
+        with patch.object(inspect, "stack") as stack:
+            assert guarded() == "ok"
+        stack.assert_not_called()
+
+    def test_is_thread_local(self):
+        """A call in flight on one thread must not make a concurrent call on
+        another thread look re-entrant."""
+        entered = threading.Event()
+        release = threading.Event()
+        results = {}
+
+        @not_recursive
+        def guarded(wait):
+            if wait:
+                entered.set()
+                release.wait(timeout=5)
+            return "ok"
+
+        def run_worker():
+            results["worker"] = guarded(wait=True)
+
+        worker = threading.Thread(target=run_worker)
+        worker.start()
+        assert entered.wait(timeout=5)
+        # `worker` holds the in-flight flag on its own thread; this call on the
+        # main thread must still succeed.
+        results["main"] = guarded(wait=False)
+        release.set()
+        worker.join(timeout=5)
+
+        assert results == {"worker": "ok", "main": "ok"}


### PR DESCRIPTION
Fixes #52

## Summary

`not_recursive` detects re-entrancy by walking `inspect.stack()` on every call and matching frames by function **name**. This is both a correctness bug and a performance cost, and this PR replaces it with a per-function thread-local in-flight flag.

### Correctness bug

The check raises `RecursionDetected` whenever *any* frame on the stack has the same function name as the guarded function — not when the function actually re-enters. So an unrelated function that merely shares the name (common names like `helper`, `wrapper`, `inner`, `get_user`) triggers a false positive, and two distinct guarded functions that share a name block each other when one calls the other.

New regression test (`tests/test_recursion.py::test_does_not_false_positive_on_unrelated_same_named_frame`) — two independently decorated functions both named `helper`, where `root()` calls `leaf()` exactly once (no recursion):

```
# against the current implementation on main:
>       assert root() == "leaf-value"
E       django_datadog_logger.recursion.RecursionDetected: function 'helper' is recursive
django_datadog_logger/recursion.py:18: RecursionDetected
```

It fails on `main` (red) and passes with this change (green).

### Performance

`inspect.stack()` walks the entire stack and resolves the source file (`getsourcefile` / realpath) of every frame, on every call. `not_recursive` wraps `get_wsgi_request_user` / `get_wsgi_request_auth`, which run for **every formatted log record**, so this is a per-log-record tax on every request path. The thread-local flag is O(1) with no stack walk and no file I/O.

Indicative microbenchmark (this environment; old impl vs the new one, guarded call made under a synthetic call stack):

| stack depth | old (`inspect.stack`) | new (thread-local) | speedup |
|---:|---:|---:|---:|
| 30  | 255 µs | 0.63 µs | ~400× |
| 60  | 425 µs | 1.02 µs | ~415× |
| 100 | 655 µs | 1.51 µs | ~430× |

(Absolute numbers vary with stack depth and `linecache` warmth; the point is the per-call cost is real and is now removed.)

## What changed

- `django_datadog_logger/recursion.py`: re-entrancy is tracked with a per-function `threading.local()` in-flight flag instead of a name-matched `inspect.stack()` walk. The flag keys on the function's identity (the closure), so it fires only on actual re-entry; the thread-local scope keeps concurrent calls on different threads independent.
- `tests/test_recursion.py` (new): direct recursion still raises, indirect recursion still raises, sequential calls work (including after an exception), the false-positive case no longer raises, the guard does not call `inspect.stack()`, and concurrent calls on different threads don't interfere.
- `HISTORY.md`: changelog entry.

## Behavior preservation

The observable contract is unchanged: direct and indirect re-entry still raise `RecursionDetected`, which the formatter already swallows into a `None` fallback. The thread-local scope preserves the previous thread-safety (each thread's stack was independent before; each thread's flag is independent now). Full suite green (`make lint`, `make test`); no version bump — left for your `bump-my-version` release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)