### PR TITLE
not_recursive: guard on function identity via request-scoped Local

### DIFF
--- a/django_datadog_logger/recursion.py
+++ b/django_datadog_logger/recursion.py
@@ -14,13 +14,24 @@ def not_recursive(f):
     Raise RecursionDetected if ``f`` is re-entered within the same logical
     request/task context.
 
-    Guards against the auth logging loop: accessing the lazy Django
-    ``request.user`` triggers authentication, which logs, which formats the
-    record and accesses ``request.user`` again. In-flight functions are tracked
-    in an ``asgiref.local.Local`` set -- the same primitive the package already
-    uses to scope the current request -- so the guard follows the request across
-    thread and sync/async boundaries (WSGI, ASGI, Celery), and is keyed on the
-    function's identity rather than its name.
+    This is a *safety* guard against the auth logging loop: accessing the lazy
+    Django ``request.user`` triggers authentication, which logs, which formats
+    the record and accesses ``request.user`` again -- an unbounded loop. Because
+    a missed loop is catastrophic (runaway recursion) while an over-eager stop
+    is benign (the formatter catches RecursionDetected and drops the user from a
+    single record), the guard is deliberately biased to fail safe.
+
+    In-flight functions are tracked in an ``asgiref.local.Local`` set, keyed on
+    the function's identity rather than its name. ``Local`` is chosen -- over a
+    plain ``threading.local`` -- because the request itself is resolved through
+    ``asgiref.local.Local`` (see ``wsgi.py``): under ASGI a single request may be
+    handled across the event-loop thread and ``sync_to_async`` executor threads,
+    so an auth loop can cross the sync/async boundary while staying within one
+    request. Scoping the guard the same way the request is scoped means such a
+    loop is still caught, whereas a thread-local flag set on one thread would not
+    be seen on another and the loop would slip through. asgiref propagates the
+    context across that boundary, so any deviation is toward over-firing (the
+    safe direction), never toward missing a loop.
     """
 
     @wraps(f)

--- a/django_datadog_logger/recursion.py
+++ b/django_datadog_logger/recursion.py
@@ -1,5 +1,8 @@
-import inspect
 from functools import wraps
+
+from asgiref.local import Local  # NOQA
+
+_local = Local()
 
 
 class RecursionDetected(RuntimeError):
@@ -8,15 +11,30 @@ class RecursionDetected(RuntimeError):
 
 def not_recursive(f):
     """
-    raise an exception if recursive
+    Raise RecursionDetected if ``f`` is re-entered within the same logical
+    request/task context.
+
+    Guards against the auth logging loop: accessing the lazy Django
+    ``request.user`` triggers authentication, which logs, which formats the
+    record and accesses ``request.user`` again. In-flight functions are tracked
+    in an ``asgiref.local.Local`` set -- the same primitive the package already
+    uses to scope the current request -- so the guard follows the request across
+    thread and sync/async boundaries (WSGI, ASGI, Celery), and is keyed on the
+    function's identity rather than its name.
     """
 
     @wraps(f)
     def wrapper(*args, **kwargs):
-        for frame in inspect.stack():
-            if f.__name__ == frame.function:
-                raise RecursionDetected(f"function '{f.__name__}' is recursive")
-
-        return f(*args, **kwargs)
+        try:
+            in_flight = _local.in_flight
+        except AttributeError:
+            in_flight = _local.in_flight = set()
+        if f in in_flight:
+            raise RecursionDetected(f"function '{f.__name__}' is recursive")
+        in_flight.add(f)
+        try:
+            return f(*args, **kwargs)
+        finally:
+            in_flight.discard(f)
 
     return wrapper

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,144 @@
+"""Tests for the `not_recursive` re-entrancy guard."""
+
+import inspect
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from django_datadog_logger.recursion import RecursionDetected, not_recursive
+
+
+def test_true_self_recursion_is_detected():
+    """A function that calls itself is stopped by the guard."""
+
+    @not_recursive
+    def recurse(n):
+        return recurse(n - 1)
+
+    with pytest.raises(RecursionDetected):
+        recurse(5)
+
+
+def test_indirect_recursion_is_detected():
+    """Re-entry through an intermediate call is blocked -- the real formatter
+    scenario (helper -> logging -> formatter -> helper)."""
+
+    @not_recursive
+    def outer():
+        def intermediate():
+            outer()
+
+        intermediate()
+
+    with pytest.raises(RecursionDetected):
+        outer()
+
+
+def test_does_not_walk_the_stack():
+    """The guard must not call ``inspect.stack()`` -- that resolved the source
+    file of every frame on every call, a per-call cost on the hot logging
+    path."""
+
+    @not_recursive
+    def guarded():
+        return "ok"
+
+    with patch.object(inspect, "stack") as stack:
+        assert guarded() == "ok"
+    stack.assert_not_called()
+
+
+def test_single_call_returns_normally():
+    """A non-recursive call returns its value and leaves no state behind."""
+
+    @not_recursive
+    def once():
+        return "value"
+
+    assert once() == "value"
+    # State is cleared, so a second independent call also succeeds.
+    assert once() == "value"
+
+
+def test_unrelated_same_named_functions_do_not_block():
+    """
+    Regression for issue #52: matching on identity, not name.
+
+    Two independently decorated functions that share a name must not block
+    each other when one calls the other.
+    """
+
+    def make_guarded(body):
+        @not_recursive
+        def helper():
+            return body()
+
+        return helper
+
+    leaf = make_guarded(lambda: "leaf-value")
+    root = make_guarded(leaf)  # different function, same name "helper"
+
+    assert root() == "leaf-value"
+
+
+def test_two_guarded_functions_call_each_other_in_one_context():
+    """Distinct guarded functions may nest within the same context."""
+
+    @not_recursive
+    def inner():
+        return "inner"
+
+    @not_recursive
+    def outer():
+        return inner()
+
+    assert outer() == "inner"
+
+
+def test_flag_cleared_after_exception():
+    """A raising call still clears its in-flight marker (finally)."""
+
+    @not_recursive
+    def boom():
+        raise ValueError("kaboom")
+
+    with pytest.raises(ValueError):
+        boom()
+    # If the marker leaked, this second call would raise RecursionDetected.
+    with pytest.raises(ValueError):
+        boom()
+
+
+def test_concurrent_threads_are_isolated():
+    """
+    A function in flight on one thread must not trip the guard on another.
+
+    Uses barriers so both threads are provably inside the guarded function at
+    the same time, then asserts neither observed a RecursionDetected.
+    """
+
+    both_inside = threading.Barrier(2)
+    errors = []
+
+    @not_recursive
+    def guarded():
+        try:
+            both_inside.wait(timeout=5)
+        except RecursionDetected as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+        return "ok"
+
+    def run():
+        try:
+            guarded()
+        except RecursionDetected as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -5,6 +5,7 @@ import threading
 from unittest.mock import patch
 
 import pytest
+from asgiref.sync import async_to_sync, sync_to_async
 
 from django_datadog_logger.recursion import RecursionDetected, not_recursive
 
@@ -33,6 +34,46 @@ def test_indirect_recursion_is_detected():
 
     with pytest.raises(RecursionDetected):
         outer()
+
+
+def test_detects_recursion_across_async_boundary():
+    """Re-entry that crosses a sync -> async -> sync hop within one request is
+    still caught.
+
+    This is the ASGI case the guard exists for: under ASGI a single request is
+    handled across the event-loop thread and ``sync_to_async`` executor threads,
+    so an auth loop can re-enter the guarded function on a *different* thread
+    while staying in the same request. Because the marker lives in an
+    ``asgiref.local.Local`` (which asgiref propagates across the boundary) rather
+    than in a thread-local, the in-flight marker set before the hop is visible
+    after it, and the loop is detected. A plain ``threading.local`` guard, bound
+    to the original thread, would not see it.
+    """
+    outer_thread = {}
+    boundary_thread = {}
+
+    @not_recursive
+    def guarded(reenter):
+        if not reenter:
+            return "leaf"
+        outer_thread["id"] = threading.get_ident()
+
+        async def bridge():
+            def reenter_guarded():
+                boundary_thread["id"] = threading.get_ident()
+                return guarded(reenter=False)  # re-entry -> must be blocked
+
+            # thread_sensitive=False forces a distinct executor thread.
+            return await sync_to_async(reenter_guarded, thread_sensitive=False)()
+
+        return async_to_sync(bridge)()
+
+    with pytest.raises(RecursionDetected):
+        guarded(reenter=True)
+
+    # The re-entry genuinely happened on another thread; the guard caught it
+    # anyway because it is scoped like the request, not like the thread.
+    assert boundary_thread["id"] != outer_thread["id"]
 
 
 def test_does_not_walk_the_stack():


### PR DESCRIPTION
Fixes #52

## What's wrong today

`not_recursive` walks `inspect.stack()` on each call and compares every frame's function **name** to the guarded function's name. Two consequences:

- **It confuses unrelated functions.** Any frame that happens to share the name trips the guard, so two independently-decorated functions named the same (`helper`, `get_user`, ...) reject each other even when nothing recurses.
- **It pays to introspect the whole stack every time.** The decorator wraps `get_wsgi_request_user` / `get_wsgi_request_auth`, which run once per formatted log record -- so every log line on a request path walks the stack and resolves each frame's source file.

## The approach here

Re-entrancy is really "is *this* function already running for *this* request?" -- a question about identity and request scope, not frame names. So the guard now holds a set of in-flight **function objects** in the `asgiref.local.Local` the package already uses to scope the current request (`wsgi.py`, `celery.py`):

- keyed on the function object, so only true re-entry fires;
- scoped to the request/task context, so it stays correct as work moves across threads and the sync/async boundary (WSGI, ASGI, Celery) -- where a thread-local would lose the request;
- O(1), no stack walk, no file resolution;
- cleared in a `finally`, so an exception or a reused thread never leaves a stale marker.

The auth-loop contract is unchanged: direct and indirect re-entry still raise `RecursionDetected`, which the formatter already turns into a `None` fallback.

## Tests

`tests/test_recursion.py` (new): direct recursion, indirect recursion, the same-name false-positive from #52, two guarded functions nesting within one context, marker cleanup after an exception, no `inspect.stack()` call, and cross-thread isolation. `make lint` and `make test` green; no version bump.